### PR TITLE
Add Windows batch scripts for screen lock and hardening

### DIFF
--- a/enable_screen_lock.bat
+++ b/enable_screen_lock.bat
@@ -1,0 +1,23 @@
+@echo off
+REM Enables the screen saver and sets the timeout to 15 minutes.
+
+REM Enable the screen saver
+reg add "HKEY_CURRENT_USER\Control Panel\Desktop" /v ScreenSaveActive /t REG_SZ /d 1 /f
+
+REM Set the screen saver to require a password on resume
+reg add "HKEY_CURRENT_USER\Control Panel\Desktop" /v ScreenSaverIsSecure /t REG_SZ /d 1 /f
+
+REM Set the screen saver timeout to 15 minutes (900 seconds)
+reg add "HKEY_CURRENT_USER\Control Panel\Desktop" /v ScreenSaveTimeOut /t REG_SZ /d 900 /f
+
+REM Set a default screen saver (e.g., scrnsave.scr - blank screen)
+REM Check if C:\Windows\System32\scrnsave.scr exists, otherwise use another default or notify user.
+IF EXIST "C:\Windows\System32\scrnsave.scr" (
+    reg add "HKEY_CURRENT_USER\Control Panel\Desktop" /v SCRNSAVE.EXE /t REG_SZ /d "C:\Windows\System32\scrnsave.scr" /f
+) ELSE (
+    echo WARNING: Default screensaver C:\Windows\System32\scrnsave.scr not found.
+    echo Please set a screensaver manually.
+)
+
+echo Screen lock settings applied.
+echo Please note that for changes to take full effect, a log off and log back in, or a system restart might be required.

--- a/harden_windows.bat
+++ b/harden_windows.bat
@@ -1,0 +1,39 @@
+@echo off
+REM Basic Windows 11 Pro hardening script
+
+echo Applying basic security settings...
+
+REM --- Windows Defender Firewall ---
+echo Enabling Windows Defender Firewall for all profiles...
+netsh advfirewall set allprofiles state on
+echo Windows Defender Firewall enabled.
+echo.
+
+REM --- User Account Control (UAC) ---
+echo Ensuring User Account Control (UAC) is enabled...
+REM EnableLUA (EnableLimitedUserAccount) to 1 is the default.
+REM This command ensures it's explicitly set. A reboot is typically required for UAC changes to take full effect if it was previously off.
+reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v EnableLUA /t REG_DWORD /d 1 /f
+echo UAC settings checked. A reboot may be required if UAC was previously disabled.
+echo.
+
+REM --- Remote Desktop ---
+echo Disabling Remote Desktop connections...
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server" /v fDenyTSConnections /t REG_DWORD /d 1 /f
+echo Remote Desktop connections disabled.
+echo.
+
+REM --- Controlled Folder Access ---
+echo --- Controlled Folder Access ---
+echo Controlled Folder Access helps protect your files and folders from unauthorized changes by unfriendly applications.
+echo Enabling it via command line is complex and may require specific SIDs or further configuration not suitable for a general script.
+echo It is recommended to configure Controlled Folder Access manually through the Windows Security app:
+echo 1. Open Windows Security.
+echo 2. Go to "Virus & threat protection".
+echo 3. Under "Ransomware protection", click "Manage ransomware protection".
+echo 4. Turn on "Controlled folder access".
+echo You can then customize protected folders and allow apps through Controlled Folder Access.
+echo.
+
+echo Basic hardening measures applied.
+echo Please review the output and consider restarting your system for all changes to take effect.


### PR DESCRIPTION
This commit introduces two new Windows batch scripts:

1.  `enable_screen_lock.bat`: This script configures the system to automatically lock the screen after 15 minutes of user inactivity. It modifies registry settings to enable the screen saver, set the timeout to 900 seconds, require a password on resume, and sets a default blank screen saver.

2.  `harden_windows.bat`: This script applies several basic security hardening measures for Windows 11 Pro systems. It includes:
    - Enabling Windows Defender Firewall for all network profiles.
    - Ensuring User Account Control (UAC) is enabled.
    - Disabling Remote Desktop connections.
    - Provides guidance for manually configuring Controlled Folder Access, as command-line setup is complex for a general script.

Both scripts include comments to explain their functionality.